### PR TITLE
fix deprecation from crypt4gh params

### DIFF
--- a/sda_uploader/__init__.py
+++ b/sda_uploader/__init__.py
@@ -1,5 +1,5 @@
 """SDA Uploader Module."""
-cli_version = "0.2.0"
+cli_version = "0.2.1"
 gui_version = "0.5.2"
-package_version = "0.5.4"
+package_version = "0.5.6"
 __version__ = package_version

--- a/sda_uploader/cli.py
+++ b/sda_uploader/cli.py
@@ -46,7 +46,7 @@ def generate_one_time_key() -> Tuple:
     _remove_file(private_key_file)
     _remove_file(public_key_file)
 
-    c4gh.generate(private_key_file, public_key_file, callback=partial(mock_callback, random_password))
+    c4gh.generate(private_key_file, public_key_file, passphrase=str.encode(random_password))
     print("One-time use encryption key generated.")
     return private_key_file, public_key_file, random_password
 


### PR DESCRIPTION
`crypt4gh==1.4` parameter `callback` in `generate` was changed to `passphrase` in `crypt4gh==1.5` (latest)

Was fixed for GUI in #15 but not for CLI