### PR TITLE
compromise fix for windows build: display cmd behind gui app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,12 @@ jobs:
         run: |
           echo '${{ secrets.DOCKER_PASSWORD }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin
           docker pull cscfi/pyinstaller
-          docker run --rm -v "${PWD}:/builder" cscfi/pyinstaller --noconsole --onefile sdagui.py --name ${{ matrix.asset_name }}
+          docker run --rm -v "${PWD}:/builder" cscfi/pyinstaller --onefile sdagui.py --name ${{ matrix.asset_name }}
           sudo chown -R $USER:$GROUP dist/
       - name: Build GUI artifact
         if: matrix.os != 'ubuntu-latest'
         run: |
-          pyinstaller --noconsole --onefile sdagui.py --name ${{ matrix.asset_name }}
+          pyinstaller --onefile sdagui.py --name ${{ matrix.asset_name }}
       - name: Build GUI Asset
         run: |
           cd ./dist


### PR DESCRIPTION
release `v0.6.1`

The Windows executable crashes, because pyinstaller is hiding the console (does not affect linux or mac, or when running with python)
- compromise fix for windows: don't hide `cmd`
  - fix it better later by refactoring how the logging works