### PR TITLE
fix bug on header check for large files

### DIFF
--- a/sda_uploader/encrypt.py
+++ b/sda_uploader/encrypt.py
@@ -21,7 +21,7 @@ def verify_crypt4gh_header(file: Union[str, Path] = "") -> bool:
     """Verify, that a file has Crypt4GH header."""
     print("Verifying file Crypt4GH header.")
     with open(file, "rb") as f:
-        header = f.read()[:8]
+        header = f.read(8)
         if header == b"crypt4gh":
             return True
         else:


### PR DESCRIPTION
It seems that the reader reads the file fully into memory before reading bytes from the beginning of the array. This caused very large files to kill the process. Changed the reading method to take the first bytes from the file instead.